### PR TITLE
Syntax error caused buffer pointer to equal 0x1

### DIFF
--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -767,7 +767,8 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
       }
     }
 
-    packet->payload = p, packet->payload_packet_len = p_len; /* Restore */
+    packet->payload = p;
+    packet->payload_packet_len = p_len; /* Restore */
     flow->l4.tcp.tls.message.buffer_used -= len;
 
     if(flow->l4.tcp.tls.message.buffer_used > 0)

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -740,7 +740,7 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	}
 
 	packet->payload = block;
-        packet->payload_packet_len = ndpi_min(block_len+4, flow->l4.tcp.tls.message.buffer_used);
+	packet->payload_packet_len = ndpi_min(block_len+4, flow->l4.tcp.tls.message.buffer_used);
 
 	if((processed+packet->payload_packet_len) > len) {
 	  something_went_wrong = 1;

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -710,7 +710,8 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
     content_type = flow->l4.tcp.tls.message.buffer[0];
 
     /* Overwriting packet payload */
-    p = packet->payload, p_len = packet->payload_packet_len; /* Backup */
+    p = packet->payload;
+    p_len = packet->payload_packet_len; /* Backup */
 
     if(content_type == 0x14 /* Change Cipher Spec */) {
       if(ndpi_struct->skip_tls_blocks_until_change_cipher) {

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -151,7 +151,7 @@ void ndpi_search_tls_tcp_memory(struct ndpi_detection_module_struct *ndpi_struct
 #endif
   }
 
-  if(avail_bytes >= packet->payload_packet_len) {
+  if(packet->payload_packet_len > 0 && avail_bytes >= packet->payload_packet_len) {
     memcpy(&flow->l4.tcp.tls.message.buffer[flow->l4.tcp.tls.message.buffer_used],
 	   packet->payload, packet->payload_packet_len);
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -142,7 +142,8 @@ void ndpi_search_tls_tcp_memory(struct ndpi_detection_module_struct *ndpi_struct
 				 flow->l4.tcp.tls.message.buffer_len, new_len);
     if(!newbuf) return;
 
-    flow->l4.tcp.tls.message.buffer = (u_int8_t*)newbuf, flow->l4.tcp.tls.message.buffer_len = new_len;
+    flow->l4.tcp.tls.message.buffer = (u_int8_t*)newbuf;
+    flow->l4.tcp.tls.message.buffer_len = new_len;
     avail_bytes = flow->l4.tcp.tls.message.buffer_len - flow->l4.tcp.tls.message.buffer_used;
 
 #ifdef DEBUG_TLS_MEMORY

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -840,7 +840,8 @@ static int ndpi_search_tls_udp(struct ndpi_detection_module_struct *ndpi_struct,
 
   processTLSBlock(ndpi_struct, flow);
 
-  packet->payload = p, packet->payload_packet_len = p_len; /* Restore */
+  packet->payload = p;
+  packet->payload_packet_len = p_len; /* Restore */
 
   ndpi_int_tls_add_connection(ndpi_struct, flow, NDPI_PROTOCOL_TLS);
 

--- a/src/lib/protocols/tls.c
+++ b/src/lib/protocols/tls.c
@@ -739,7 +739,8 @@ static int ndpi_search_tls_tcp(struct ndpi_detection_module_struct *ndpi_struct,
 	  break;
 	}
 
-	packet->payload = block, packet->payload_packet_len = ndpi_min(block_len+4, flow->l4.tcp.tls.message.buffer_used);
+	packet->payload = block;
+        packet->payload_packet_len = ndpi_min(block_len+4, flow->l4.tcp.tls.message.buffer_used);
 
 	if((processed+packet->payload_packet_len) > len) {
 	  something_went_wrong = 1;


### PR DESCRIPTION
Possible copy-paste from lines 141-142?

Relevant stack dump:
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f1806f42af1 in free () from /lib64/libc.so.6
#1  0x00007f180777328d in ndpi_free (ptr=0x1) at ndpi_main.c:113
#2  0x00007f180777f9a5 in ndpi_init_packet_header (ndpi_str=0x7f17d01c4010, flow=0x7f178488b370, packetlen=76) at ndpi_main.c:3716
#3  0x00007f1807782b9f in ndpi_detection_process_packet (ndpi_str=0x7f17d01c4010, flow=0x7f178488b370,
    packet=0x7f177eb83c6a <error: Cannot access memory at address 0x7f177eb83c6a>, packetlen=76, current_time_ms=1604495709604, src=0x7f17845e2dd0, dst=0x7f17845e2eb8)
    at ndpi_main.c:4645
